### PR TITLE
add configuration options to exclude devices and hubs in homebridge ui

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -20,6 +20,22 @@
         "type": "boolean",
         "default": true,
         "required": true
+      },
+      "ignoreHubSns": {
+        "title":"Ignore Hubs",
+        "type": "array",
+        "items": {
+          "title": "Hub serial number",
+          "type": "string"
+        }
+      },
+      "ignoreDeviceSns": {
+        "title":"Ignore Devices",
+        "type": "array",
+        "items": {
+          "title": "Device serial number",
+          "type": "string"
+        }
       }
     }
   }


### PR DESCRIPTION
Hi, thanks for the great plugin! In addition to the Eufy doorbell I am using Eufy cameras that are HomeKit compatible, i.e. I don't want them to be added to my Homebridge as well. I found some code in platform.ts which seems to do exactly what I need but I haven't found anything to configure it. Not sure if I missed something but this code allows to specify the serial numbers of devices and hubs in the standard Homebridge UI. Thanks, Thilo